### PR TITLE
Use persist storage for last queued block #

### DIFF
--- a/django_bitcoin/jsonrpc/authproxy.py
+++ b/django_bitcoin/jsonrpc/authproxy.py
@@ -46,10 +46,15 @@ USER_AGENT = "AuthServiceProxy/0.1"
 
 HTTP_TIMEOUT = settings.HTTP_TIMEOUT_AUTHPROXY
 
+
 class JSONRPCException(Exception):
     def __init__(self, rpcError):
         Exception.__init__(self)
         self.error = rpcError
+
+    def __str__(self):
+        return "JSONRPCException %d: %s" % (self.error.get('code'),
+                                            self.error.get('message'))
 
 class AuthServiceProxy(object):
     def __init__(self, serviceURL, serviceName=None):
@@ -93,7 +98,10 @@ class AuthServiceProxy(object):
         if httpresp is None:
             raise JSONRPCException({
               'code' : -342, 'message' : 'missing HTTP response from server'})
-
+        if httpresp.status >= 400:
+            error = '%d (%s)' % (httpresp.status, httpresp.reason)
+            raise JSONRPCException({
+              'code' : -342, 'message' : 'error HTTP response from server: %s' % error})
         resp = json.loads(httpresp.read(), parse_float=decimal.Decimal)
         #print resp
         if resp['error'] != None:

--- a/django_bitcoin/jsonrpc/authproxy.py
+++ b/django_bitcoin/jsonrpc/authproxy.py
@@ -52,7 +52,7 @@ class JSONRPCException(Exception):
         Exception.__init__(self)
         self.error = rpcError
 
-    def __str__(self):
+    def __unicode__(self):
         return "JSONRPCException %d: %s" % (self.error.get('code'),
                                             self.error.get('message'))
 
@@ -103,7 +103,6 @@ class AuthServiceProxy(object):
             raise JSONRPCException({
               'code' : -342, 'message' : 'error HTTP response from server: %s' % error})
         resp = json.loads(httpresp.read(), parse_float=decimal.Decimal)
-        #print resp
         if resp['error'] != None:
             raise JSONRPCException(unicode(resp['error']))
         elif 'result' not in resp:

--- a/django_bitcoin/management/commands/QueryTransactionsTaskExecute.py
+++ b/django_bitcoin/management/commands/QueryTransactionsTaskExecute.py
@@ -1,0 +1,18 @@
+from django.core.management.base import NoArgsCommand
+from time import sleep, time
+from django_bitcoin.utils import bitcoind
+from django_bitcoin.models import BitcoinAddress, DepositTransaction
+from django_bitcoin.tasks import query_transactions
+from django.conf import settings
+from decimal import Decimal
+import datetime
+
+RUN_TIME_SECONDS = 60
+
+
+class Command(NoArgsCommand):
+    help = """Executes query_transactions task
+"""
+
+    def handle_noargs(self, **options):
+        query_transactions()

--- a/django_bitcoin/migrations/0022_auto__add_persistintcache.py
+++ b/django_bitcoin/migrations/0022_auto__add_persistintcache.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'PersistIntCache'
+        db.create_table(u'django_bitcoin_persistintcache', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(unique=True, max_length=32, db_index=True)),
+            ('value', self.gf('django.db.models.fields.BigIntegerField')()),
+        ))
+        db.send_create_signal(u'django_bitcoin', ['PersistIntCache'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'PersistIntCache'
+        db.delete_table(u'django_bitcoin_persistintcache')
+
+
+    models = {
+        u'django_bitcoin.bitcoinaddress': {
+            'Meta': {'object_name': 'BitcoinAddress'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'address': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'least_received': ('django.db.models.fields.DecimalField', [], {'default': "'0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'least_received_confirmed': ('django.db.models.fields.DecimalField', [], {'default': "'0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'migrated_to_transactions': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'wallet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'addresses'", 'null': 'True', 'to': u"orm['django_bitcoin.Wallet']"})
+        },
+        u'django_bitcoin.bitcoinhistory': {
+            'Meta': {'object_name': 'BitcoinHistory'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'pending'", 'max_length': '8'})
+        },
+        u'django_bitcoin.deposittransaction': {
+            'Meta': {'object_name': 'DepositTransaction'},
+            'address': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_bitcoin.BitcoinAddress']"}),
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'confirmations': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'from_bitcoinaddress': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'transaction': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['django_bitcoin.WalletTransaction']", 'null': 'True'}),
+            'txid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'under_execution': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'wallet': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_bitcoin.Wallet']"})
+        },
+        u'django_bitcoin.historicalprice': {
+            'Meta': {'object_name': 'HistoricalPrice'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'params': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'price': ('django.db.models.fields.DecimalField', [], {'max_digits': '16', 'decimal_places': '2'})
+        },
+        u'django_bitcoin.outgoingtransaction': {
+            'Meta': {'object_name': 'OutgoingTransaction'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'executed_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True'}),
+            'expires_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_bitcoinaddress': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'txid': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'under_execution': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'django_bitcoin.payment': {
+            'Meta': {'object_name': 'Payment'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'amount_paid': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'paid_at': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True'}),
+            'transactions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['django_bitcoin.Transaction']", 'symmetrical': 'False'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {}),
+            'withdrawn_total': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'})
+        },
+        u'django_bitcoin.persistintcache': {
+            'Meta': {'object_name': 'PersistIntCache'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '32', 'db_index': 'True'}),
+            'value': ('django.db.models.fields.BigIntegerField', [], {})
+        },
+        u'django_bitcoin.transaction': {
+            'Meta': {'object_name': 'Transaction'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'django_bitcoin.wallet': {
+            'Meta': {'object_name': 'Wallet'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'last_balance': ('django.db.models.fields.DecimalField', [], {'default': "'0'", 'max_digits': '16', 'decimal_places': '8'}),
+            'transaction_counter': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'transactions_with': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['django_bitcoin.Wallet']", 'through': u"orm['django_bitcoin.WalletTransaction']", 'symmetrical': 'False'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'django_bitcoin.wallettransaction': {
+            'Meta': {'object_name': 'WalletTransaction', '_ormbases': [u'django_bitcoin.BitcoinHistory']},
+            u'bitcoinhistory_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['django_bitcoin.BitcoinHistory']", 'unique': 'True', 'primary_key': 'True'}),
+            'deposit_address': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_bitcoin.BitcoinAddress']", 'null': 'True'}),
+            'deposit_transaction': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['django_bitcoin.DepositTransaction']", 'unique': 'True', 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'from_wallet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sent_transactions'", 'null': 'True', 'to': u"orm['django_bitcoin.Wallet']"}),
+            'outgoing_transaction': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['django_bitcoin.OutgoingTransaction']", 'null': 'True'}),
+            'to_bitcoinaddress': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'to_wallet': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'received_transactions'", 'null': 'True', 'to': u"orm['django_bitcoin.Wallet']"}),
+            'txid': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'wt_type': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['django_bitcoin']

--- a/django_bitcoin/models.py
+++ b/django_bitcoin/models.py
@@ -97,6 +97,10 @@ class DepositTransaction(models.Model):
 #     confirmations = models.IntegerField(default=0)
 #     parent = models.ForeignKey('BitcoinBlock')
 
+class PersistIntCache(models.Model):
+    key = models.CharField(max_length=32, db_index=True, unique=True)
+    value = models.BigIntegerField()
+
 class OutgoingTransaction(models.Model):
 
     created_at = models.DateTimeField(default=datetime.datetime.now)

--- a/django_bitcoin/settings.py
+++ b/django_bitcoin/settings.py
@@ -87,7 +87,13 @@ ENABLE_INTERNAL_TRANSACTIONS = getattr(
     settings,
     "ENABLE_INTERNAL_TRANSACTIONS",
     True)
+
 HTTP_TIMEOUT_AUTHPROXY = getattr(
     settings,
     "HTTP_TIMEOUT_AUTHPROXY",
     60)
+
+BITCOIN_START_BLOCK = getattr(
+    settings,
+    "BITCOIN_START_BLOCK",
+    338400)

--- a/django_bitcoin/tasks.py
+++ b/django_bitcoin/tasks.py
@@ -42,7 +42,11 @@ def query_transactions():
     logger = get_task_logger('bitcoin_transactions')
 
     with NonBlockingCacheLock("query_transactions_ongoing"):
-        info = bitcoind.bitcoind_api.getinfo()
+        try:
+            info = bitcoind.bitcoind_api.getinfo()
+        except Exception as e:
+            logger.error("query_transactions: exception %s" % e)
+            return
         testnet = info['testnet']
 
         blockcount = bitcoind.bitcoind_api.getblockcount()

--- a/django_bitcoin/tasks.py
+++ b/django_bitcoin/tasks.py
@@ -60,10 +60,7 @@ def query_transactions():
             block = PersistIntCache.objects.create(key="queried_block_index",
                                                    value=query_block)
         blockhash = bitcoind.bitcoind_api.getblockhash(query_block)
-        # print query_block, blockhash
         transactions = bitcoind.bitcoind_api.listsinceblock(blockhash)
-        # print transactions
-        #transactions = [tx for tx in transactions["transactions"] if tx["category"]=="receive"]
         print transactions["transactions"]
         for tx in transactions["transactions"]:
             if tx["category"] == "receive":

--- a/django_bitcoin/tasks.py
+++ b/django_bitcoin/tasks.py
@@ -56,7 +56,7 @@ def query_transactions():
             block = PersistIntCache.objects.get(key="queried_block_index")
             query_block = min(block.value, max_query_block)
         except:
-            query_block = blockcount - 100
+            query_block = 338400
             block = PersistIntCache.objects.create(key="queried_block_index",
                                                    value=query_block)
         blockhash = bitcoind.bitcoind_api.getblockhash(query_block)

--- a/django_bitcoin/tasks.py
+++ b/django_bitcoin/tasks.py
@@ -55,8 +55,8 @@ def query_transactions():
         try:
             block = PersistIntCache.objects.get(key="queried_block_index")
             query_block = min(block.value, max_query_block)
-        except:
-            query_block = 338400
+        except PersistIntCache.DoesNotExist:
+            query_block = settings.BITCOIN_START_BLOCK
             block = PersistIntCache.objects.create(key="queried_block_index",
                                                    value=query_block)
         blockhash = bitcoind.bitcoind_api.getblockhash(query_block)


### PR DESCRIPTION
Added PersistIntCache, key 'queried_block_index' is responsible for last fetched block (can be rolled back for retry if something wrong happens).
Added jsonrpc connect exception handling (logged as errors instead of backtrace)
Added BITCOIN_START_BLOCK to settings.py - block from which fetching started